### PR TITLE
Add Google Sign-In authentication

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,16 @@ import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import GlobalStyle from './globalStyle';
 import AllRoutes from './routes/Routes';
+import Login from './pages/Login';
+import { useAuth } from './hooks/useAuth';
 
 function App() {
+  const { loading, isAllowed } = useAuth();
+
+  if (loading) return null;
+
+  if (!isAllowed) return <Login />;
+
   return (
     <BrowserRouter>
       <GlobalStyle />

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+import { onAuthStateChanged, signInWithPopup, signOut, User } from 'firebase/auth';
+import { auth, googleProvider } from '../lib/firebase';
+
+const ALLOWED_EMAIL = 'joaommattedi@gmail.com';
+
+export function useAuth() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
+    return unsubscribe;
+  }, []);
+
+  const isAllowed = user?.email === ALLOWED_EMAIL;
+
+  async function signIn() {
+    await signInWithPopup(auth, googleProvider);
+  }
+
+  async function logOut() {
+    await signOut(auth);
+  }
+
+  return { user, loading, isAllowed, signIn, logOut };
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app';
 import { getFirestore } from 'firebase/firestore';
+import { getAuth, GoogleAuthProvider } from 'firebase/auth';
 
 const firebaseConfig = {
   apiKey: 'AIzaSyA9-epeEcvvj_2Y74t-cclSO4pxOYPX_rM',
@@ -12,3 +13,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
+export const auth = getAuth(app);
+export const googleProvider = new GoogleAuthProvider();

--- a/src/pages/Finance/index.tsx
+++ b/src/pages/Finance/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useAuth } from '../../hooks/useAuth';
 import { useFinance } from './hooks/useFinance';
 import Dashboard from './components/Dashboard';
 import TransactionForm from './components/TransactionForm';
@@ -55,6 +56,7 @@ export default function Finance() {
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [seeding, setSeeding] = useState(false);
 
+  const { logOut } = useAuth();
   const { loading, addTransaction, updateTransaction, deleteTransaction, getByMonth, getTotals, seedFixedExpenses } = useFinance();
 
   const monthTransactions = getByMonth(year, month);
@@ -83,7 +85,10 @@ export default function Finance() {
 
   return (
     <PageWrapper>
-      <PageTitle>Finanças</PageTitle>
+      <ColumnHeader style={{ marginBottom: '2rem' }}>
+        <PageTitle style={{ margin: 0 }}>Finanças</PageTitle>
+        <SeedButton type="button" onClick={logOut}>Sair</SeedButton>
+      </ColumnHeader>
 
       <Section>
         <MonthRow>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useAuth } from '../hooks/useAuth';
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 1.5rem;
+  background: #fafafa;
+`;
+
+const Title = styled.h1`
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #111;
+`;
+
+const GoogleButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 6px;
+  color: #111;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  padding: 0.65rem 1.25rem;
+  transition: box-shadow 0.15s;
+
+  &:hover {
+    box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+  }
+`;
+
+const GoogleIcon = () => (
+  <svg width="18" height="18" viewBox="0 0 48 48">
+    <path fill="#4285F4" d="M44.5 20H24v8.5h11.8C34.7 33.9 29.9 37 24 37c-7.2 0-13-5.8-13-13s5.8-13 13-13c3.1 0 5.9 1.1 8.1 2.9l6.4-6.4C34.6 4.1 29.6 2 24 2 11.8 2 2 11.8 2 24s9.8 22 22 22c11 0 21-8 21-22 0-1.3-.2-2.7-.5-4z"/>
+    <path fill="#34A853" d="M6.3 14.7l7 5.1C15 16.1 19.2 13 24 13c3.1 0 5.9 1.1 8.1 2.9l6.4-6.4C34.6 4.1 29.6 2 24 2c-7.6 0-14.2 4.5-17.7 11.2-.1 0 0 1.5 0 1.5z"/>
+    <path fill="#FBBC05" d="M24 46c5.5 0 10.5-1.9 14.3-5l-6.6-5.4C29.6 37.5 26.9 38.5 24 38.5c-5.8 0-10.7-3.9-12.4-9.2l-7 5.4C8 41.5 15.4 46 24 46z"/>
+    <path fill="#EA4335" d="M44.5 20H24v8.5h11.8c-1 3-3.2 5.5-6.1 7l6.6 5.4C40.5 37 44.5 31 44.5 24c0-1.3-.2-2.7-.5-4z"/>
+  </svg>
+);
+
+const DeniedMessage = styled.p`
+  font-size: 0.875rem;
+  color: #dc2626;
+`;
+
+const SignOutLink = styled.button`
+  background: none;
+  border: none;
+  color: #888;
+  cursor: pointer;
+  font-size: 0.8rem;
+  text-decoration: underline;
+`;
+
+export default function Login() {
+  const { user, signIn, logOut } = useAuth();
+
+  if (user) {
+    return (
+      <Wrapper>
+        <Title>Acesso negado</Title>
+        <DeniedMessage>{user.email} não tem permissão.</DeniedMessage>
+        <SignOutLink onClick={logOut}>Sair e tentar outra conta</SignOutLink>
+      </Wrapper>
+    );
+  }
+
+  return (
+    <Wrapper>
+      <Title>Finanças</Title>
+      <GoogleButton onClick={signIn}>
+        <GoogleIcon />
+        Entrar com Google
+      </GoogleButton>
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
## Summary

- Firebase Google Auth restricted to `joaommattedi@gmail.com`
- Login page with "Entrar com Google" button
- Access denied screen for unauthorized accounts
- Logout button in the Finance page header
- All routes gated — no content visible without authentication

## Before merging

Enable Google Sign-In in Firebase Console:
**Authentication → Sign-in method → Google → Enable**

## Test plan

- [ ] Visit the site and confirm the login screen appears
- [ ] Sign in with `joaommattedi@gmail.com` and confirm access is granted
- [ ] Sign in with another Google account and confirm "Acesso negado" is shown
- [ ] Click "Sair" and confirm it returns to the login screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)