### PR TITLE
Add spending insights, accordion expense tables, and sort by amount

### DIFF
--- a/src/pages/Finance/components/SpendingInsights.tsx
+++ b/src/pages/Finance/components/SpendingInsights.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Transaction } from '../types';
+import {
+  InsightsCard,
+  InsightsGrid,
+  InsightsSection,
+  InsightsSectionTitle,
+  CategoryRow,
+  CategoryName,
+  BarTrack,
+  BarFill,
+  CategoryPct,
+  BigExpenseCard,
+  BigExpenseLabel,
+  BigExpenseDesc,
+  BigExpenseMeta,
+} from './styles';
+
+interface SpendingInsightsProps {
+  expenses: Transaction[];
+  income: number;
+}
+
+function fmt(value: number) {
+  return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+export default function SpendingInsights({ expenses, income }: SpendingInsightsProps) {
+  if (expenses.length === 0) return null;
+
+  const totalExpense = expenses.reduce((acc, t) => acc + t.amount, 0);
+
+  // Group by category
+  const byCategory = expenses.reduce<Record<string, number>>((acc, t) => {
+    acc[t.category] = (acc[t.category] ?? 0) + t.amount;
+    return acc;
+  }, {});
+
+  const categories = Object.entries(byCategory)
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 6); // top 6
+
+  // Biggest single expense
+  const biggest = [...expenses].sort((a, b) => b.amount - a.amount)[0];
+  const biggestPctIncome = income > 0 ? (biggest.amount / income) * 100 : 0;
+
+  return (
+    <InsightsCard>
+      <InsightsGrid>
+        <InsightsSection>
+          <InsightsSectionTitle>Gastos por categoria</InsightsSectionTitle>
+          {categories.map(([cat, amount]) => {
+            const pct = totalExpense > 0 ? (amount / totalExpense) * 100 : 0;
+            return (
+              <CategoryRow key={cat}>
+                <CategoryName title={cat}>{cat}</CategoryName>
+                <BarTrack>
+                  <BarFill pct={pct} />
+                </BarTrack>
+                <CategoryPct>{Math.round(pct)}%</CategoryPct>
+              </CategoryRow>
+            );
+          })}
+        </InsightsSection>
+
+        <InsightsSection>
+          <InsightsSectionTitle>Maior gasto</InsightsSectionTitle>
+          <BigExpenseCard>
+            <BigExpenseLabel>{biggest.category} · {biggest.date.split('-').reverse().join('/')}</BigExpenseLabel>
+            <BigExpenseDesc title={biggest.description}>{biggest.description}</BigExpenseDesc>
+            <BigExpenseMeta>
+              {fmt(biggest.amount)}
+              {income > 0 && ` · ${biggestPctIncome.toFixed(1)}% da receita`}
+            </BigExpenseMeta>
+          </BigExpenseCard>
+        </InsightsSection>
+      </InsightsGrid>
+    </InsightsCard>
+  );
+}

--- a/src/pages/Finance/components/TransactionList.tsx
+++ b/src/pages/Finance/components/TransactionList.tsx
@@ -26,6 +26,7 @@ interface TransactionListProps {
   transactions: Transaction[];
   onEdit: (transaction: Transaction) => void;
   onDelete: (id: string) => void;
+  attached?: boolean;
 }
 
 function fmt(value: number) {
@@ -37,11 +38,11 @@ function fmtDate(dateStr: string) {
   return `${day}/${month}/${year}`;
 }
 
-export default function TransactionList({ type, transactions, onEdit, onDelete }: TransactionListProps) {
+export default function TransactionList({ type, transactions, onEdit, onDelete, attached }: TransactionListProps) {
   const total = transactions.reduce((acc, t) => acc + t.amount, 0);
 
   return (
-    <TableWrapper>
+    <TableWrapper attached={attached}>
       {transactions.length === 0 ? (
         <EmptyState>Nenhuma {type === 'income' ? 'receita' : 'despesa'} neste mês.</EmptyState>
       ) : (

--- a/src/pages/Finance/components/styles.tsx
+++ b/src/pages/Finance/components/styles.tsx
@@ -294,12 +294,157 @@ export const SubmitButton = styled.button`
   }
 `;
 
-/* ─── Transaction Table ───────────────────────────────────────── */
+/* ─── Spending Insights ───────────────────────────────────────── */
 
-export const TableWrapper = styled.div`
+export const InsightsCard = styled.div`
   background: #fff;
   border: 1px solid #e5e5e5;
   border-radius: 8px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 1rem;
+`;
+
+export const InsightsGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const InsightsSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+`;
+
+export const InsightsSectionTitle = styled.p`
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+`;
+
+export const CategoryRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+`;
+
+export const CategoryName = styled.span`
+  font-size: 0.78rem;
+  color: #555;
+  width: 90px;
+  flex-shrink: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const BarTrack = styled.div`
+  flex: 1;
+  background: #f0f0f0;
+  border-radius: 99px;
+  height: 6px;
+  overflow: hidden;
+`;
+
+interface BarFillProps {
+  pct: number;
+}
+
+export const BarFill = styled.div<BarFillProps>`
+  background: #dc2626;
+  border-radius: 99px;
+  height: 100%;
+  width: ${({ pct }) => pct}%;
+  transition: width 0.3s;
+`;
+
+export const CategoryPct = styled.span`
+  font-size: 0.75rem;
+  color: #888;
+  width: 32px;
+  text-align: right;
+  flex-shrink: 0;
+`;
+
+export const BigExpenseCard = styled.div`
+  background: #fafafa;
+  border: 1px solid #f0f0f0;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+`;
+
+export const BigExpenseLabel = styled.p`
+  font-size: 0.75rem;
+  color: #888;
+  margin-bottom: 0.25rem;
+`;
+
+export const BigExpenseDesc = styled.p`
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #111;
+  margin-bottom: 0.15rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const BigExpenseMeta = styled.p`
+  font-size: 0.78rem;
+  color: #dc2626;
+`;
+
+/* ─── Accordion ───────────────────────────────────────────────── */
+
+export const AccordionHeader = styled.button<{ open: boolean }>`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #f5f5f5;
+  border: 1px solid #e5e5e5;
+  border-radius: ${({ open }) => (open ? '6px 6px 0 0' : '6px')};
+  cursor: pointer;
+  padding: 0.55rem 0.75rem;
+  margin-bottom: 0;
+  transition: background 0.15s;
+
+  &:hover {
+    background: #efefef;
+  }
+
+  span:first-child {
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: #444;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  span:last-child {
+    font-size: 0.7rem;
+    color: #888;
+    transform: rotate(${({ open }) => (open ? '0deg' : '-90deg')});
+    transition: transform 0.2s;
+    display: inline-block;
+    line-height: 1;
+  }
+`;
+
+/* ─── Transaction Table ───────────────────────────────────────── */
+
+export const TableWrapper = styled.div<{ attached?: boolean }>`
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-top: ${({ attached }) => (attached ? 'none' : '1px solid #e5e5e5')};
+  border-radius: ${({ attached }) => (attached ? '0 0 6px 6px' : '8px')};
   overflow: hidden;
 `;
 

--- a/src/pages/Finance/index.tsx
+++ b/src/pages/Finance/index.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import { useFinance } from './hooks/useFinance';
 import Dashboard from './components/Dashboard';
+import SpendingInsights from './components/SpendingInsights';
 import TransactionForm from './components/TransactionForm';
 import TransactionList from './components/TransactionList';
 import EditModal from './components/EditModal';
@@ -21,6 +22,7 @@ import {
   SortLabel,
   SortSelect,
   SortDirButton,
+  AccordionHeader,
 } from './components/styles';
 import { Transaction } from './types';
 
@@ -29,7 +31,7 @@ const MONTHS = [
   'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro',
 ];
 
-type SortField = 'date' | 'createdAt';
+type SortField = 'date' | 'createdAt' | 'amount';
 type SortDir = 'asc' | 'desc';
 
 function sortTransactions(list: Transaction[], field: SortField, dir: SortDir) {
@@ -39,6 +41,9 @@ function sortTransactions(list: Transaction[], field: SortField, dir: SortDir) {
     if (field === 'date') {
       aVal = new Date(a.date + 'T00:00:00').getTime();
       bVal = new Date(b.date + 'T00:00:00').getTime();
+    } else if (field === 'amount') {
+      aVal = a.amount;
+      bVal = b.amount;
     } else {
       aVal = a.createdAt ?? new Date(a.date + 'T00:00:00').getTime();
       bVal = b.createdAt ?? new Date(b.date + 'T00:00:00').getTime();
@@ -55,14 +60,20 @@ export default function Finance() {
   const [sortField, setSortField] = useState<SortField>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [seeding, setSeeding] = useState(false);
+  const [fixedOpen, setFixedOpen] = useState(true);
+  const [variableOpen, setVariableOpen] = useState(true);
 
   const { logOut } = useAuth();
   const { loading, addTransaction, updateTransaction, deleteTransaction, getByMonth, getTotals, seedFixedExpenses } = useFinance();
 
   const monthTransactions = getByMonth(year, month);
   const sorted = sortTransactions(monthTransactions, sortField, sortDir);
+
   const incomeTransactions = sorted.filter((t) => t.type === 'income');
-  const expenseTransactions = sorted.filter((t) => t.type === 'expense');
+  const allExpenses = sorted.filter((t) => t.type === 'expense');
+  const fixedExpenses = allExpenses.filter((t) => t.isFixed);
+  const variableExpenses = allExpenses.filter((t) => !t.isFixed);
+
   const { income, expense, balance } = getTotals(monthTransactions);
 
   function prevMonth() {
@@ -99,6 +110,13 @@ export default function Finance() {
         <Dashboard income={income} expense={expense} balance={balance} />
       </Section>
 
+      {allExpenses.length > 0 && (
+        <Section>
+          <SectionTitle>Análise de gastos</SectionTitle>
+          <SpendingInsights expenses={allExpenses} income={income} />
+        </Section>
+      )}
+
       <Section>
         <SectionTitle>Nova transação</SectionTitle>
         <TransactionForm onAdd={addTransaction} />
@@ -109,6 +127,7 @@ export default function Finance() {
         <SortSelect value={sortField} onChange={(e) => setSortField(e.target.value as SortField)}>
           <option value="date">Data da transação</option>
           <option value="createdAt">Horário de cadastro</option>
+          <option value="amount">Valor</option>
         </SortSelect>
         <SortDirButton
           type="button"
@@ -136,12 +155,42 @@ export default function Finance() {
               {seeding ? 'Adicionando...' : '+ Despesas fixas'}
             </SeedButton>
           </ColumnHeader>
-          <TransactionList
-            type="expense"
-            transactions={expenseTransactions}
-            onEdit={setEditing}
-            onDelete={deleteTransaction}
-          />
+
+          {fixedExpenses.length > 0 && (
+            <div style={{ marginBottom: '1rem' }}>
+              <AccordionHeader open={fixedOpen} onClick={() => setFixedOpen((o) => !o)}>
+                <span>Fixas ({fixedExpenses.length})</span>
+                <span>▾</span>
+              </AccordionHeader>
+              {fixedOpen && (
+                <TransactionList
+                  type="expense"
+                  transactions={fixedExpenses}
+                  onEdit={setEditing}
+                  onDelete={deleteTransaction}
+                  attached
+                />
+              )}
+            </div>
+          )}
+
+          <AccordionHeader
+            open={variableOpen}
+            onClick={() => setVariableOpen((o) => !o)}
+            style={{ marginTop: fixedExpenses.length > 0 ? '0.25rem' : 0 }}
+          >
+            <span>Variáveis ({variableExpenses.length})</span>
+            <span>▾</span>
+          </AccordionHeader>
+          {variableOpen && (
+            <TransactionList
+              type="expense"
+              transactions={variableExpenses}
+              onEdit={setEditing}
+              onDelete={deleteTransaction}
+              attached
+            />
+          )}
         </Column>
       </TwoColumns>
 


### PR DESCRIPTION
## Summary

- **Spending Insights dashboard** above the transaction form: category breakdown with horizontal bars (top 6 by spend) + biggest single expense card showing value and % of income
- **Accordion expense tables**: fixed and variable expenses are separate collapsible sections — visible header with background, border, hover state, and rotating arrow indicator
- **Table attaches to accordion header** seamlessly (shared border, no gap)
- **Sort by value** added as a third sort option alongside date and insertion time

## Test plan

- [ ] Confirm "Análise de gastos" section appears when there are expenses and shows correct category percentages
- [ ] Confirm biggest expense card shows correct value and % of income
- [ ] Click "Fixas" and "Variáveis" accordion headers to collapse/expand each section
- [ ] Verify accordion arrow rotates when closed
- [ ] Select "Valor" from the sort dropdown and confirm transactions reorder correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)