### PR TITLE
Add paid status tracking for expenses

### DIFF
--- a/src/pages/Finance/components/SpendingInsights.tsx
+++ b/src/pages/Finance/components/SpendingInsights.tsx
@@ -19,16 +19,18 @@ import {
 interface SpendingInsightsProps {
   expenses: Transaction[];
   income: number;
+  paidExpense: number;
 }
 
 function fmt(value: number) {
   return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 }
 
-export default function SpendingInsights({ expenses, income }: SpendingInsightsProps) {
+export default function SpendingInsights({ expenses, income, paidExpense }: SpendingInsightsProps) {
   if (expenses.length === 0) return null;
 
   const totalExpense = expenses.reduce((acc, t) => acc + t.amount, 0);
+  const paidPercent = totalExpense > 0 ? Math.round((paidExpense / totalExpense) * 100) : 0;
 
   // Group by category
   const byCategory = expenses.reduce<Record<string, number>>((acc, t) => {
@@ -71,6 +73,15 @@ export default function SpendingInsights({ expenses, income }: SpendingInsightsP
             <BigExpenseMeta>
               {fmt(biggest.amount)}
               {income > 0 && ` · ${biggestPctIncome.toFixed(1)}% da receita`}
+            </BigExpenseMeta>
+          </BigExpenseCard>
+
+          <InsightsSectionTitle style={{ marginTop: '1rem' }}>Contas pagas</InsightsSectionTitle>
+          <BigExpenseCard>
+            <BigExpenseLabel>{fmt(paidExpense)} de {fmt(totalExpense)}</BigExpenseLabel>
+            <BigExpenseDesc>{paidPercent}%</BigExpenseDesc>
+            <BigExpenseMeta style={{ color: '#16a34a' }}>
+              {totalExpense - paidExpense > 0 ? `${fmt(totalExpense - paidExpense)} restantes` : 'Tudo pago!'}
             </BigExpenseMeta>
           </BigExpenseCard>
         </InsightsSection>

--- a/src/pages/Finance/components/TransactionList.tsx
+++ b/src/pages/Finance/components/TransactionList.tsx
@@ -18,6 +18,7 @@ import {
   TableTotal,
   TotalLabel,
   TotalValue,
+  PaidCheckbox,
 } from './styles';
 import { Transaction, TransactionType } from '../types';
 
@@ -27,6 +28,7 @@ interface TransactionListProps {
   onEdit: (transaction: Transaction) => void;
   onDelete: (id: string) => void;
   attached?: boolean;
+  onTogglePaid?: (id: string, isPaid: boolean) => void;
 }
 
 function fmt(value: number) {
@@ -38,7 +40,7 @@ function fmtDate(dateStr: string) {
   return `${day}/${month}/${year}`;
 }
 
-export default function TransactionList({ type, transactions, onEdit, onDelete, attached }: TransactionListProps) {
+export default function TransactionList({ type, transactions, onEdit, onDelete, attached, onTogglePaid }: TransactionListProps) {
   const total = transactions.reduce((acc, t) => acc + t.amount, 0);
 
   return (
@@ -54,6 +56,7 @@ export default function TransactionList({ type, transactions, onEdit, onDelete, 
               {type === 'expense' && <Th>Conta</Th>}
               <Th>Data</Th>
               <ThRight>Valor</ThRight>
+              {type === 'expense' && <Th style={{ textAlign: 'center' }}>Pago</Th>}
               <Th></Th>
             </Tr>
           </Thead>
@@ -70,6 +73,16 @@ export default function TransactionList({ type, transactions, onEdit, onDelete, 
                 <TdRight>
                   <Amount type={type}>{fmt(t.amount)}</Amount>
                 </TdRight>
+                {type === 'expense' && (
+                  <Td style={{ textAlign: 'center' }}>
+                    <PaidCheckbox
+                      type="checkbox"
+                      checked={t.isPaid ?? false}
+                      onChange={(e) => onTogglePaid?.(t.id, e.target.checked)}
+                      title={t.isPaid ? 'Marcar como não pago' : 'Marcar como pago'}
+                    />
+                  </Td>
+                )}
                 <Td style={{ whiteSpace: 'nowrap' }}>
                   <EditButton onClick={() => onEdit(t)} title="Editar">✎</EditButton>
                   <DeleteButton onClick={() => onDelete(t.id)} title="Excluir">×</DeleteButton>

--- a/src/pages/Finance/components/styles.tsx
+++ b/src/pages/Finance/components/styles.tsx
@@ -149,6 +149,12 @@ export const CardValue = styled.p<CardValueProps>`
   color: ${({ variant }) => (variant ? valueColors[variant] : '#111')};
 `;
 
+export const CardSubLabel = styled.p`
+  font-size: 0.7rem;
+  color: #aaa;
+  margin-top: 0.25rem;
+`;
+
 /* ─── Month Selector ──────────────────────────────────────────── */
 
 export const MonthRow = styled.div`
@@ -635,6 +641,13 @@ export const SaveButton = styled.button`
   &:hover {
     opacity: 0.8;
   }
+`;
+
+export const PaidCheckbox = styled.input`
+  cursor: pointer;
+  width: 15px;
+  height: 15px;
+  accent-color: #16a34a;
 `;
 
 export const EmptyState = styled.p`

--- a/src/pages/Finance/hooks/useFinance.ts
+++ b/src/pages/Finance/hooks/useFinance.ts
@@ -36,6 +36,10 @@ export function useFinance() {
     await deleteDoc(doc(db, COLLECTION, id));
   }, []);
 
+  const togglePaid = useCallback(async (id: string, isPaid: boolean) => {
+    await updateDoc(doc(db, COLLECTION, id), { isPaid });
+  }, []);
+
   const updateTransaction = useCallback(async (id: string, data: Omit<Transaction, 'id'>) => {
     await updateDoc(doc(db, COLLECTION, id), { ...data });
   }, []);
@@ -98,5 +102,5 @@ export function useFinance() {
     [transactions],
   );
 
-  return { transactions, loading, addTransaction, updateTransaction, deleteTransaction, getByMonth, getTotals, seedFixedExpenses };
+  return { transactions, loading, addTransaction, updateTransaction, deleteTransaction, togglePaid, getByMonth, getTotals, seedFixedExpenses };
 }

--- a/src/pages/Finance/index.tsx
+++ b/src/pages/Finance/index.tsx
@@ -64,7 +64,7 @@ export default function Finance() {
   const [variableOpen, setVariableOpen] = useState(true);
 
   const { logOut } = useAuth();
-  const { loading, addTransaction, updateTransaction, deleteTransaction, getByMonth, getTotals, seedFixedExpenses } = useFinance();
+  const { loading, addTransaction, updateTransaction, deleteTransaction, togglePaid, getByMonth, getTotals, seedFixedExpenses } = useFinance();
 
   const monthTransactions = getByMonth(year, month);
   const sorted = sortTransactions(monthTransactions, sortField, sortDir);
@@ -75,6 +75,9 @@ export default function Finance() {
   const variableExpenses = allExpenses.filter((t) => !t.isFixed);
 
   const { income, expense, balance } = getTotals(monthTransactions);
+  const paidExpense = monthTransactions
+    .filter((t) => t.type === 'expense' && t.isPaid)
+    .reduce((acc, t) => acc + t.amount, 0);
 
   function prevMonth() {
     if (month === 1) { setMonth(12); setYear((y) => y - 1); }
@@ -113,7 +116,7 @@ export default function Finance() {
       {allExpenses.length > 0 && (
         <Section>
           <SectionTitle>Análise de gastos</SectionTitle>
-          <SpendingInsights expenses={allExpenses} income={income} />
+          <SpendingInsights expenses={allExpenses} income={income} paidExpense={paidExpense} />
         </Section>
       )}
 
@@ -168,6 +171,7 @@ export default function Finance() {
                   transactions={fixedExpenses}
                   onEdit={setEditing}
                   onDelete={deleteTransaction}
+                  onTogglePaid={togglePaid}
                   attached
                 />
               )}
@@ -188,6 +192,7 @@ export default function Finance() {
               transactions={variableExpenses}
               onEdit={setEditing}
               onDelete={deleteTransaction}
+              onTogglePaid={togglePaid}
               attached
             />
           )}

--- a/src/pages/Finance/types.ts
+++ b/src/pages/Finance/types.ts
@@ -8,6 +8,7 @@ export interface Transaction {
   category: string;
   date: string; // ISO date string YYYY-MM-DD
   isFixed?: boolean; // only for expenses
+  isPaid?: boolean; // only for expenses
   createdAt?: number; // ms timestamp for insertion-order sorting
   account?: string;
 }


### PR DESCRIPTION
- Add `isPaid` field to Transaction type
- Add `togglePaid` function in useFinance to update Firestore
- Add "Pago" checkbox column in expense table (fixed and variable accordions)
- Add "Contas pagas" card in SpendingInsights below biggest expense