### PR TITLE
Add payment method breakdown to spending insights

### DIFF
--- a/src/pages/Finance/components/SpendingInsights.tsx
+++ b/src/pages/Finance/components/SpendingInsights.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Transaction } from '../types';
 import {
   InsightsCard,
   InsightsGrid,
   InsightsSection,
   InsightsSectionTitle,
+  InsightsSectionHeader,
+  InsightsDivider,
   CategoryRow,
   CategoryName,
+  PaymentMethodName,
   BarTrack,
   BarFill,
   CategoryValue,
@@ -15,6 +18,8 @@ import {
   BigExpenseMeta,
   PaidProgressTrack,
   PaidProgressFill,
+  ViewToggle,
+  ViewToggleBtn,
 } from './styles';
 
 interface SpendingInsightsProps {
@@ -28,6 +33,8 @@ function fmt(value: number) {
 }
 
 export default function SpendingInsights({ expenses, income, paidExpense }: SpendingInsightsProps) {
+  const [viewMode, setViewMode] = useState<'value' | 'pct'>('value');
+
   if (expenses.length === 0) return null;
 
   const totalExpense = expenses.reduce((acc, t) => acc + t.amount, 0);
@@ -41,7 +48,16 @@ export default function SpendingInsights({ expenses, income, paidExpense }: Spen
 
   const categories = Object.entries(byCategory)
     .sort(([, a], [, b]) => b - a)
-    .slice(0, 6); // top 6
+    .slice(0, 6);
+
+  // Group by payment method
+  const byAccount = expenses.reduce<Record<string, number>>((acc, t) => {
+    const key = t.account || 'Sem método';
+    acc[key] = (acc[key] ?? 0) + t.amount;
+    return acc;
+  }, {});
+
+  const accountEntries = Object.entries(byAccount).sort(([, a], [, b]) => b - a);
 
   // Biggest single expense
   const biggest = [...expenses].sort((a, b) => b.amount - a.amount)[0];
@@ -96,6 +112,32 @@ export default function SpendingInsights({ expenses, income, paidExpense }: Spen
           </BigExpenseCard>
         </InsightsSection>
       </InsightsGrid>
+
+      <InsightsDivider />
+
+      <InsightsSection>
+        <InsightsSectionHeader>
+          <InsightsSectionTitle>Gastos por meio de pagamento</InsightsSectionTitle>
+          <ViewToggle>
+            <ViewToggleBtn active={viewMode === 'value'} onClick={() => setViewMode('value')}>R$</ViewToggleBtn>
+            <ViewToggleBtn active={viewMode === 'pct'} onClick={() => setViewMode('pct')}>%</ViewToggleBtn>
+          </ViewToggle>
+        </InsightsSectionHeader>
+        {accountEntries.map(([method, amount]) => {
+          const pct = totalExpense > 0 ? (amount / totalExpense) * 100 : 0;
+          return (
+            <CategoryRow key={method}>
+              <PaymentMethodName title={method}>{method}</PaymentMethodName>
+              <BarTrack>
+                <BarFill pct={pct} color="#3b82f6" />
+              </BarTrack>
+              <CategoryValue>
+                {viewMode === 'value' ? fmt(amount) : `${Math.round(pct)}%`}
+              </CategoryValue>
+            </CategoryRow>
+          );
+        })}
+      </InsightsSection>
     </InsightsCard>
   );
 }

--- a/src/pages/Finance/components/styles.tsx
+++ b/src/pages/Finance/components/styles.tsx
@@ -428,6 +428,50 @@ export const CategoryValue = styled.span`
   white-space: nowrap;
 `;
 
+export const PaymentMethodName = styled(CategoryName)`
+  width: 110px;
+`;
+
+export const InsightsDivider = styled.div`
+  border-top: 1px solid #f0f0f0;
+`;
+
+export const InsightsSectionHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const ViewToggle = styled.div`
+  display: flex;
+  gap: 2px;
+  background: #f0f0f0;
+  border-radius: 6px;
+  padding: 2px;
+`;
+
+interface ViewToggleBtnProps {
+  active: boolean;
+}
+
+export const ViewToggleBtn = styled.button<ViewToggleBtnProps>`
+  background: ${({ active }) => (active ? '#fff' : 'transparent')};
+  border: none;
+  border-radius: 4px;
+  color: ${({ active }) => (active ? '#111' : '#888')};
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: ${({ active }) => (active ? '600' : '400')};
+  padding: 0.2rem 0.5rem;
+  transition: all 0.15s;
+  box-shadow: ${({ active }) => (active ? '0 1px 2px rgba(0,0,0,0.1)' : 'none')};
+  white-space: nowrap;
+
+  &:hover {
+    color: #111;
+  }
+`;
+
 export const BigExpenseCard = styled.div`
   background: #f8fafc;
   border: 1px solid #e2e8f0;


### PR DESCRIPTION
New section in the analysis card shows expenses grouped by payment method with a toggle to switch between R$ and % views. Bars use blue to visually distinguish from the slate category bars. Expenses with no method set appear as 'Sem método'.