### PR TITLE
Rename account field to payment method with expanded options

### DIFF
--- a/src/pages/Finance/components/EditModal.tsx
+++ b/src/pages/Finance/components/EditModal.tsx
@@ -97,7 +97,7 @@ export default function EditModal({ transaction, onSave, onClose }: EditModalPro
         </Select>
 
         <Select value={account} onChange={(e) => setAccount(e.target.value)}>
-          <option value="">Conta / Cartão</option>
+          <option value="">Método de pagamento</option>
           {ACCOUNTS.map((a) => (
             <option key={a} value={a}>{a}</option>
           ))}

--- a/src/pages/Finance/components/TransactionForm.tsx
+++ b/src/pages/Finance/components/TransactionForm.tsx
@@ -97,7 +97,7 @@ export default function TransactionForm({ onAdd }: TransactionFormProps) {
       </Select>
 
       <Select value={account} onChange={(e) => setAccount(e.target.value)}>
-        <option value="">Conta / Cartão</option>
+        <option value="">Método de pagamento</option>
         {ACCOUNTS.map((a) => (
           <option key={a} value={a}>{a}</option>
         ))}

--- a/src/pages/Finance/components/TransactionList.tsx
+++ b/src/pages/Finance/components/TransactionList.tsx
@@ -53,7 +53,7 @@ export default function TransactionList({ type, transactions, onEdit, onDelete, 
             <Tr>
               <Th>Descrição</Th>
               <Th>Categoria</Th>
-              {type === 'expense' && <Th>Conta</Th>}
+              {type === 'expense' && <Th>Pagamento</Th>}
               <Th>Data</Th>
               <ThRight>Valor</ThRight>
               {type === 'expense' && <Th style={{ textAlign: 'center' }}>Pago</Th>}

--- a/src/pages/Finance/types.ts
+++ b/src/pages/Finance/types.ts
@@ -13,7 +13,7 @@ export interface Transaction {
   account?: string;
 }
 
-export const ACCOUNTS = ['Itaú', 'Nubank'] as const;
+export const ACCOUNTS = ['PIX', 'Crédito Itaú', 'Crédito Nubank', 'Débito Nubank'] as const;
 
 export const EXPENSE_CATEGORIES = [
   'Mercado',


### PR DESCRIPTION
Replace 'Itaú' / 'Nubank' with PIX, Crédito Itaú, Crédito Nubank, Débito Nubank. Update placeholder and table column header accordingly.